### PR TITLE
Fixed error on create extension "Create extension credcheck; ERROR: function warning_valid_until() does not exist"

### DIFF
--- a/credcheck--4.0.0.sql
+++ b/credcheck--4.0.0.sql
@@ -100,7 +100,7 @@ REVOKE ALL ON FUNCTION pg_banned_role_reset() FROM PUBLIC;
 REVOKE ALL ON FUNCTION pg_banned_role_reset(name) FROM PUBLIC;
 
 -- Add event trigger for valid until warning
-DROP FUNCTION warning_valid_until();
+DROP FUNCTION IF EXISTS warning_valid_until();
 CREATE OR REPLACE FUNCTION warning_valid_until()
   RETURNS event_trigger AS
 $$


### PR DESCRIPTION
Create extension is failing with error.
 ERROR: function warning_valid_until() does not exist
 
 Fixed it via adding 'IF EXISTS' condition in the sql file.
