### PR TITLE
Updated the functionality of 'username_contain' and 'username_not_contain' gucs

### DIFF
--- a/credcheck.c
+++ b/credcheck.c
@@ -273,15 +273,20 @@ static char *to_nlower(const char *str, size_t max) {
 }
 
 static bool str_contains(const char *chars, const char *str) {
-  for (const char *i = str; *i; i++) {
-    for (const char *j = chars; *j; j++) {
-      if (*i == *j) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+    char *chars_copy;
+    char *token;
+    /* Make a copy of chars since strtok modifies the string */
+    chars_copy = pstrdup(chars);
+    
+    token = strtok(chars_copy, ",");
+    while (token != NULL) {
+        if (strstr(str, token) != NULL) {
+            return true;
+        }
+        token = strtok(NULL, ",");
+    }    
+    pfree(chars_copy);
+    return false;
 }
 
 static void check_str_counters(const char *str, int *lower, int *upper,

--- a/test/expected/01_username.out
+++ b/test/expected/01_username.out
@@ -151,3 +151,16 @@ CREATE USER aa;
 ERROR:  username does not contain the configured credcheck.username_min_digit characters (1)
 DROP USER aa;
 ERROR:  role "aa" does not exist
+SET credcheck.username_contain TO 'ba,c';
+DROP USER IF EXISTS "b$auser1";
+NOTICE:  role "b$auser1" does not exist, skipping
+CREATE USER "b$auser1" WITH PASSWORD 'dummy';
+ERROR:  username does not contain the configured credcheck.username_contain characters: ba,c
+DROP USER IF EXISTS "ba$user1";
+NOTICE:  role "ba$user1" does not exist, skipping
+CREATE USER "ba$user1" WITH PASSWORD 'dummy';
+DROP USER IF EXISTS "ba$user1";
+DROP USER IF EXISTS "c$user1";
+NOTICE:  role "c$user1" does not exist, skipping
+CREATE USER "c$user1" WITH PASSWORD 'dummy';
+DROP USER IF EXISTS "c$user1";

--- a/test/sql/01_username.sql
+++ b/test/sql/01_username.sql
@@ -116,3 +116,13 @@ DROP USER "a$user1";
 CREATE USER aa;
 DROP USER aa;
 
+SET credcheck.username_contain TO 'ba,c';
+DROP USER IF EXISTS "b$auser1";
+CREATE USER "b$auser1" WITH PASSWORD 'dummy';
+DROP USER IF EXISTS "ba$user1";
+CREATE USER "ba$user1" WITH PASSWORD 'dummy';
+DROP USER IF EXISTS "ba$user1";
+DROP USER IF EXISTS "c$user1";
+CREATE USER "c$user1" WITH PASSWORD 'dummy';
+DROP USER IF EXISTS "c$user1";
+


### PR DESCRIPTION
In this PR I have updated how the username_contain and username_not_contain gucs works.
Earlier it used to rely on characters and just run a for loop on it. I have updated it to tokenize with the comma delimiter which would allow users to use substrings as well.

Earlied : 'a,b,c' , 'ab,c', 'abc' were all treated as equal.
I am proposing this PR so that all these guc values can be treated as different. I have added few tests also.

