### PR TITLE
TAP test: skip gracefully on PostgreSQL < 15

### DIFF
--- a/t/001_history_replication.pl
+++ b/t/001_history_replication.pl
@@ -10,6 +10,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+# Skip on PostgreSQL < 15: the Custom WAL Resource Manager API
+# (RegisterCustomRmgr) was introduced in PG 15.
+my ($pg_major) = (`pg_config --version` =~ /(\d+)/);
+plan skip_all => "this test requires PostgreSQL 15 or later"
+	if $pg_major < 15;
+
 # Set up primary
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(allows_streaming => 1);


### PR DESCRIPTION
The replication test relies on the Custom WAL Resource Manager API (RegisterCustomRmgr), which was introduced in PostgreSQL 15.  Without a version guard the test would either fail to set up the cluster or error out in an unclear way on older installations.

Add a skip_all plan guard that parses the major version from `pg_config --version` output.