### PR TITLE
Fix off-by-one buffer overflow in to_nlower()

### DIFF
--- a/credcheck.c
+++ b/credcheck.c
@@ -350,7 +350,7 @@ static char *to_nlower(const char *str, size_t max) {
   char *lower_str;
   int i = 0;
 
-  lower_str = (char *)calloc(strlen(str), sizeof(char));
+  lower_str = (char *)calloc(strlen(str) + 1, sizeof(char));
 
   for (const char *p = str; *p && i < max; p++) {
     lower_str[i++] = tolower(*p);


### PR DESCRIPTION
calloc(strlen(str), sizeof(char)) allocates exactly strlen(str) bytes, leaving no room for the null terminator. After the loop processes all characters, the write lower_str[i] = '\0' lands one byte past the allocated buffer — undefined behavior.

Allocate strlen(str) + 1 bytes instead, so the null terminator slot is always within bounds regardless of whether the loop was truncated by max or ran to completion.

Found with AddressSanitizer.