### PR TITLE
Remove redundant PG_MAJORVERSION variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,6 @@ REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 
 PG_CONFIG = pg_config
 
-# Extract the major version number
-PG_MAJORVERSION := $(shell $(PG_CONFIG) --version | sed -e 's/^[a-zA-Z ]*//' -e 's/\..*//')
-
 TAP_TESTS = 1
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)


### PR DESCRIPTION
Mentioned variable is not used anywhere after 02fa131f888762dc18450ca6253356c4e6a45dd2