### PR TITLE
Fix privilege escalation via self ALTER ROLE when password_valid_until is set

### DIFF
--- a/credcheck.c
+++ b/credcheck.c
@@ -1932,6 +1932,7 @@ cc_ProcessUtility(PEL_PROCESSUTILITY_PROTO)
 				ListCell      *option;
 				char          *password;
 				bool           save_password = false;
+				bool           has_other_option = false;
 				DefElem    *dvalidUntil = NULL;
 				DefElem    *dpassword = NULL;
 
@@ -1966,6 +1967,11 @@ cc_ProcessUtility(PEL_PROCESSUTILITY_PROTO)
 					else if (strcmp(defel->defname, "validUntil") == 0)
 					{
 						dvalidUntil = defel;
+					}
+					else
+					{
+						/* any other role option (SUPERUSER, CREATEROLE, ...) */
+						has_other_option = true;
 					}
 				}
 
@@ -2020,8 +2026,12 @@ cc_ProcessUtility(PEL_PROCESSUTILITY_PROTO)
 					 * 	Only roles with the CREATEROLE attribute and the ADMIN option
 					 * 	on role "..." may alter this role.
 					 * force use of the superuser privilege to modify the password user.
+					 * Restrict this elevation to a pure password change on the caller's
+					 * own role, otherwise privileged options (SUPERUSER, CREATEROLE, ...)
+					 * would run as the bootstrap superuser.
 					 */
-					if (!superuser() && get_rolespec_oid(stmt->role, false) == GetUserId())
+					if (!superuser() && dpassword != NULL && !has_other_option
+						&& get_rolespec_oid(stmt->role, false) == GetUserId())
 						use_superuser_priv = true;
 				}
 

--- a/test/expected/07_valid_until.out
+++ b/test/expected/07_valid_until.out
@@ -68,3 +68,49 @@ SELECT count(*), '1' AS "expected" FROM pg_password_history ;
 (1 row)
 
 DROP USER aaa;
+--
+-- Privilege escalation regression: a non-superuser altering their own role must
+-- never be elevated to superuser just because credcheck auto-injects a VALID
+-- UNTIL clause. Only a pure password change on the caller's own role may be run
+-- with elevated privileges.
+--
+CREATE USER low_priv;
+SET ROLE low_priv;
+-- Attempt to smuggle privileged options into a self ALTER ROLE; must not elevate
+DO $$
+DECLARE
+	escalated boolean;
+BEGIN
+	BEGIN
+		ALTER ROLE low_priv CREATEDB;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+    BEGIN
+		ALTER ROLE low_priv CREATEROLE;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	BEGIN
+		ALTER ROLE low_priv BYPASSRLS;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	BEGIN
+		ALTER ROLE low_priv SUPERUSER;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	BEGIN
+		ALTER ROLE low_priv PASSWORD 'SomePass2' SUPERUSER;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	SELECT rolsuper OR rolcreaterole OR rolcreatedb OR rolbypassrls
+		INTO escalated FROM pg_roles WHERE rolname = current_role;
+	IF escalated THEN
+		RAISE NOTICE 'FAIL: low_priv gained privileges';
+	ELSE
+		RAISE NOTICE 'PASS: no privilege escalation';
+	END IF;
+END $$;
+NOTICE:  PASS: no privilege escalation
+-- A plain self password change must still be accepted (elevation still works)
+ALTER ROLE low_priv PASSWORD 'SomePass3';
+RESET ROLE;
+DROP ROLE low_priv;

--- a/test/sql/07_valid_until.sql
+++ b/test/sql/07_valid_until.sql
@@ -51,3 +51,49 @@ select rolname, rolvaliduntil between now() + '59 days'::interval and now() + '6
 -- History must have one entry
 SELECT count(*), '1' AS "expected" FROM pg_password_history ;
 DROP USER aaa;
+
+--
+-- Privilege escalation regression: a non-superuser altering their own role must
+-- never be elevated to superuser just because credcheck auto-injects a VALID
+-- UNTIL clause. Only a pure password change on the caller's own role may be run
+-- with elevated privileges.
+--
+CREATE USER low_priv;
+SET ROLE low_priv;
+-- Attempt to smuggle privileged options into a self ALTER ROLE; must not elevate
+DO $$
+DECLARE
+	escalated boolean;
+BEGIN
+	BEGIN
+		ALTER ROLE low_priv CREATEDB;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+    BEGIN
+		ALTER ROLE low_priv CREATEROLE;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	BEGIN
+		ALTER ROLE low_priv BYPASSRLS;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	BEGIN
+		ALTER ROLE low_priv SUPERUSER;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	BEGIN
+		ALTER ROLE low_priv PASSWORD 'SomePass2' SUPERUSER;
+	EXCEPTION WHEN OTHERS THEN NULL;
+	END;
+	SELECT rolsuper OR rolcreaterole OR rolcreatedb OR rolbypassrls
+		INTO escalated FROM pg_roles WHERE rolname = current_role;
+	IF escalated THEN
+		RAISE NOTICE 'FAIL: low_priv gained privileges';
+	ELSE
+		RAISE NOTICE 'PASS: no privilege escalation';
+	END IF;
+END $$;
+-- A plain self password change must still be accepted (elevation still works)
+ALTER ROLE low_priv PASSWORD 'SomePass3';
+RESET ROLE;
+DROP ROLE low_priv;


### PR DESCRIPTION
When `credcheck.password_valid_until` is enabled, `cc_ProcessUtility()` injected a VALID UNTIL clause into a user's own ALTER ROLE and, because a non-superuser cannot set VALID UNTIL on their role, ran the statement as `BOOTSTRAP_SUPERUSERID` to let the password change through. The whole caller-supplied statement was executed with superuser rights, so any authenticated role could grant itself
SUPERUSER/CREATEROLE/CREATEDB/BYPASSRLS simply by running e.g. "ALTER ROLE <self> <OPTION>".

Restrict the elevation to a pure password change on the caller's own role: the statement is only run with superuser privilege when its sole option is PASSWORD (plus the VALID UNTIL clause credcheck injects itself). Any other role option makes credcheck skip the elevation and let core enforce its normal permission checks, which reject the attempt.

Updated a regression test to 07_valid_until asserting that a non-superuser cannot gain role attributes through a self ALTER ROLE while password_valid_until is enabled, and that a plain self password change is still accepted.